### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -3,6 +3,10 @@ on:
   release:
     types: published
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sellnat77/Guarden/security/code-scanning/1](https://github.com/sellnat77/Guarden/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the scopes required by this workflow. For this job, the actions used (`actions/checkout`, `docker/metadata-action`, `docker/build-push-action`, `docker login` with a secret) do not require write access to repository contents; they primarily need read access to the repo and, optionally, read access to packages. Pushing to GHCR uses the personal/access token from `secrets.GUARDEN_BUILD_TOKEN`, not `GITHUB_TOKEN`, so GHCR write scopes are covered by that secret, not by the workflow’s permissions block.

The single best fix with minimal behavioral change is to add a `permissions` block at the workflow root (top level, alongside `on` and `jobs`) specifying least-privilege read access, e.g.:

```yaml
permissions:
  contents: read
  packages: read
```

This will apply to all jobs (currently just `docker`) unless overridden at job level. To implement this, edit `.github/workflows/build-containers.yaml` and insert the `permissions` section between the `on:` block and the `jobs:` block (or just before `jobs:`), maintaining indentation consistent with other top-level keys. No additional methods, imports, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
