### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sellnat77/Guarden/security/code-scanning/3](https://github.com/sellnat77/Guarden/security/code-scanning/3)

In general, to fix this problem you should explicitly define a `permissions:` block that restricts the GITHUB_TOKEN to the least privileges needed. For a lint/build workflow that only checks out code and installs dependencies, `contents: read` is typically sufficient. Defining this at the root of the workflow applies to all jobs that don’t override it.

The best minimal fix without changing existing functionality is to add a top-level `permissions:` section right after the `name: Build` line, setting `contents: read`. This documents the intent, ensures the workflow won’t accidentally gain broader permissions if repository defaults change, and satisfies CodeQL. No changes are needed inside the jobs themselves, and no external libraries or imports are involved, since this is purely GitHub Actions YAML configuration.

Concretely:
- Edit `.github/workflows/lint.yaml`.
- After line `1: name: Build`, insert:

```yaml
permissions:
  contents: read
```

- Leave the rest of the file unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
