### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   lint-npm:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/sellnat77/Guarden/security/code-scanning/2](https://github.com/sellnat77/Guarden/security/code-scanning/2)

In general, the fix is to add an explicit `permissions:` block to the workflow, either at the top level (affecting all jobs) or within each job, and restrict it to the least privileges required. For this lint/build workflow, the jobs only need to check out code and install dependencies, which requires read access to repository contents and, optionally, read access to packages if you want to be future‑proof. No write permissions are needed.

The single best fix with minimal functional change is to add a workflow‑level `permissions:` block right after the `on:` section. This ensures both `lint-npm` and `lint-pip` inherit the same minimal permissions without altering any job logic. A suitable configuration is:

```yaml
permissions:
  contents: read
  packages: read
```

You only need to edit `.github/workflows/lint.yaml`. Insert the `permissions:` block between the existing `on:` block (lines 3–7) and the `jobs:` block (line 9). No imports or other definitions are necessary, as this is standard GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
